### PR TITLE
Adjustments for Navbar with props

### DIFF
--- a/src/components/Navbar/Content/index.tsx
+++ b/src/components/Navbar/Content/index.tsx
@@ -69,6 +69,8 @@ function NavbarContentLayout({
 export default function NavbarContent({
   heroImages,
   titleImages,
+  isAlgolia,
+  isToggle
 }: NavbarProps
 ) {
   const windowSize = useWindowSize();
@@ -79,6 +81,8 @@ export default function NavbarContent({
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
   const searchBarItem = items.find((item) => item.type === 'search');
+  const searchComponent = isAlgolia ? <AlgoliaSearchBar/> : <div/>
+
   return (
     <NavbarContentLayout
       left={
@@ -87,15 +91,15 @@ export default function NavbarContent({
             <NavbarLogo heroImages={heroImages} titleImages={titleImages} />
           </div>
           {!isLanding && <NavbarItems items={leftItems} />}
-          {!searchBarItem && !isMobile && !isLanding && <AlgoliaSearchBar />}
-          {!isMobile && isDocumentation && (
+          {!searchBarItem && !isMobile && !isLanding && searchComponent}
+          {!isMobile && isDocumentation && isToggle && (
             <NavbarColorModeToggle className={styles.colorModeToggle} />
           )}
         </>
       }
       right={
         <>
-          {(isLanding || (!isMobile && !isDocumentation)) && (
+          {(isLanding || (!isMobile && !isDocumentation)) && isToggle && (
             <NavbarColorModeToggle className={styles.colorModeToggle} />
           )}
           <NavbarItems items={rightItems} />

--- a/src/components/Navbar/Content/index.tsx
+++ b/src/components/Navbar/Content/index.tsx
@@ -69,8 +69,8 @@ function NavbarContentLayout({
 export default function NavbarContent({
   heroImages,
   titleImages,
-  isAlgolia,
-  isToggle
+  isAlgoliaActive,
+  isThemeSwitcherShown
 }: NavbarProps
 ) {
   const windowSize = useWindowSize();
@@ -81,7 +81,7 @@ export default function NavbarContent({
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
   const searchBarItem = items.find((item) => item.type === 'search');
-  const searchComponent = isAlgolia ? <AlgoliaSearchBar/> : <div/>
+  const searchComponent = isAlgoliaActive ? <AlgoliaSearchBar/> : <div/>
 
   return (
     <NavbarContentLayout
@@ -92,14 +92,14 @@ export default function NavbarContent({
           </div>
           {!isLanding && <NavbarItems items={leftItems} />}
           {!searchBarItem && !isMobile && !isLanding && searchComponent}
-          {!isMobile && isDocumentation && isToggle && (
+          {!isMobile && isDocumentation && isThemeSwitcherShown && (
             <NavbarColorModeToggle className={styles.colorModeToggle} />
           )}
         </>
       }
       right={
         <>
-          {(isLanding || (!isMobile && !isDocumentation)) && isToggle && (
+          {(isLanding || (!isMobile && !isDocumentation)) && isThemeSwitcherShown && (
             <NavbarColorModeToggle className={styles.colorModeToggle} />
           )}
           <NavbarItems items={rightItems} />

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,16 +4,20 @@ import NavbarContent from './Content';
 export interface NavbarProps {
   heroImages?: { logo: string; title?: string };
   titleImages?: { light: string; dark: string };
+  isAlgolia?: boolean
+  isToggle?: boolean
 }
 
 export function Navbar({
   heroImages,
   titleImages,
+  isAlgolia,
+  isToggle
 }: NavbarProps
 ) {
   return (
     <NavbarLayout>
-      <NavbarContent heroImages={heroImages} titleImages={titleImages} />
+      <NavbarContent isToggle={isToggle} isAlgolia={isAlgolia} heroImages={heroImages} titleImages={titleImages} />
     </NavbarLayout>
   );
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,20 +4,20 @@ import NavbarContent from './Content';
 export interface NavbarProps {
   heroImages?: { logo: string; title?: string };
   titleImages?: { light: string; dark: string };
-  isAlgolia?: boolean
-  isToggle?: boolean
+  isAlgoliaActive?: boolean
+  isThemeSwitcherShown?: boolean
 }
 
 export function Navbar({
   heroImages,
   titleImages,
-  isAlgolia,
-  isToggle
+  isAlgoliaActive,
+  isThemeSwitcherShown
 }: NavbarProps
 ) {
   return (
     <NavbarLayout>
-      <NavbarContent isToggle={isToggle} isAlgolia={isAlgolia} heroImages={heroImages} titleImages={titleImages} />
+      <NavbarContent isThemeSwitcherShown={isThemeSwitcherShown} isAlgoliaActive={isAlgoliaActive} heroImages={heroImages} titleImages={titleImages} />
     </NavbarLayout>
   );
 }


### PR DESCRIPTION
For more managable Navbar we added following props to `<Navbar/>`:
 * `isAlgolia` - decides if there is a search engine in docs or not
 * `isToggle` - decides if there is a theme switch in docs