### PR TITLE
Add props to Navbar Mobile

### DIFF
--- a/src/components/AlgoliaSearchBar/styles.module.css
+++ b/src/components/AlgoliaSearchBar/styles.module.css
@@ -45,6 +45,7 @@ button[class*='DocSearch-Button'] {
   flex: 1;
   width: 100%;
   padding-left: 16px;
+  margin: 0 !important;
 
   font-weight: 400;
   font-family: var(--swm-title-font);

--- a/src/components/Navbar/Content/index.tsx
+++ b/src/components/Navbar/Content/index.tsx
@@ -69,8 +69,8 @@ function NavbarContentLayout({
 export default function NavbarContent({
   heroImages,
   titleImages,
-  isAlgoliaActive = true,
-  isThemeSwitcherShown = true,
+  isAlgoliaActive,
+  isThemeSwitcherShown,
 }: NavbarProps) {
   const windowSize = useWindowSize();
   const isMobile = windowSize === 'mobile';

--- a/src/components/Navbar/Layout/index.tsx
+++ b/src/components/Navbar/Layout/index.tsx
@@ -21,8 +21,12 @@ function NavbarBackdrop(props: { onClick: () => void; className?: string }) {
 
 export default function NavbarLayout({
   children,
+  isThemeSwitcherShown,
+  isAlgoliaActive,
 }: {
   children: React.ReactNode;
+  isThemeSwitcherShown: boolean;
+  isAlgoliaActive: boolean;
 }) {
   const {
     navbar: { hideOnScroll, style },
@@ -55,7 +59,10 @@ export default function NavbarLayout({
       )}>
       {children}
       <NavbarBackdrop onClick={mobileSidebar.toggle} />
-      <NavbarMobileSidebar />
+      <NavbarMobileSidebar
+        isAlgoliaActive={isAlgoliaActive}
+        isThemeSwitcherShown={isThemeSwitcherShown}
+      />
     </nav>
   );
 }

--- a/src/components/Navbar/MobileSidebar/Header/index.tsx
+++ b/src/components/Navbar/MobileSidebar/Header/index.tsx
@@ -20,11 +20,17 @@ function CloseButton() {
     </button>
   );
 }
-export default function NavbarMobileSidebarHeader() {
+export default function NavbarMobileSidebarHeader({
+  isThemeSwitcherShown,
+}: {
+  isThemeSwitcherShown?: boolean;
+}) {
   return (
     <div className="navbar-sidebar__brand">
       <NavbarLogo />
-      <NavbarColorModeToggle className="margin-right--md" />
+      {isThemeSwitcherShown && (
+        <NavbarColorModeToggle className="margin-right--md" />
+      )}
       <CloseButton />
     </div>
   );

--- a/src/components/Navbar/MobileSidebar/Layout/index.tsx
+++ b/src/components/Navbar/MobileSidebar/Layout/index.tsx
@@ -12,9 +12,11 @@ function isActive(path: string, locationPathname: string) {
 
 export default function NavbarMobileSidebarLayout({
   header,
+  isAlgoliaActive,
   secondaryMenu,
 }: {
   header: ReactNode;
+  isAlgoliaActive?: boolean;
   primaryMenu?: ReactNode;
   secondaryMenu: ReactNode;
 }) {
@@ -32,7 +34,7 @@ export default function NavbarMobileSidebarLayout({
   return (
     <div className="navbar-sidebar">
       {header}
-      {!isLanding && <AlgoliaSearchBar />}
+      {!isLanding && isAlgoliaActive && <AlgoliaSearchBar />}
       <div className={clsx('navbar-sidebar__items')}>
         <div className="navbar-sidebar__item menu">{secondaryMenu}</div>
       </div>

--- a/src/components/Navbar/MobileSidebar/index.tsx
+++ b/src/components/Navbar/MobileSidebar/index.tsx
@@ -7,7 +7,13 @@ import NavbarMobileSidebarHeader from '../MobileSidebar/Header';
 import NavbarMobileSidebarPrimaryMenu from '../MobileSidebar/PrimaryMenu';
 import NavbarMobileSidebarSecondaryMenu from '../MobileSidebar/SecondaryMenu';
 
-export default function NavbarMobileSidebar() {
+export default function NavbarMobileSidebar({
+  isThemeSwitcherShown,
+  isAlgoliaActive,
+}: {
+  isThemeSwitcherShown?: boolean;
+  isAlgoliaActive?: boolean;
+}) {
   const mobileSidebar = useNavbarMobileSidebar();
   useLockBodyScroll(mobileSidebar.shown);
   if (!mobileSidebar.shouldRender) {
@@ -15,7 +21,12 @@ export default function NavbarMobileSidebar() {
   }
   return (
     <NavbarMobileSidebarLayout
-      header={<NavbarMobileSidebarHeader />}
+      isAlgoliaActive={isAlgoliaActive}
+      header={
+        <NavbarMobileSidebarHeader
+          isThemeSwitcherShown={isThemeSwitcherShown}
+        />
+      }
       primaryMenu={<NavbarMobileSidebarPrimaryMenu />}
       secondaryMenu={<NavbarMobileSidebarSecondaryMenu />}
     />

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,20 +4,26 @@ import NavbarContent from './Content';
 export interface NavbarProps {
   heroImages?: { logo: string; title?: string };
   titleImages?: { light: string; dark: string };
-  isAlgoliaActive?: boolean
-  isThemeSwitcherShown?: boolean
+  isAlgoliaActive?: boolean;
+  isThemeSwitcherShown?: boolean;
 }
 
 export function Navbar({
   heroImages,
   titleImages,
-  isAlgoliaActive,
-  isThemeSwitcherShown
-}: NavbarProps
-) {
+  isAlgoliaActive = true,
+  isThemeSwitcherShown = true,
+}: NavbarProps) {
   return (
-    <NavbarLayout>
-      <NavbarContent isThemeSwitcherShown={isThemeSwitcherShown} isAlgoliaActive={isAlgoliaActive} heroImages={heroImages} titleImages={titleImages} />
+    <NavbarLayout
+      isAlgoliaActive={isAlgoliaActive}
+      isThemeSwitcherShown={isThemeSwitcherShown}>
+      <NavbarContent
+        isThemeSwitcherShown={isThemeSwitcherShown}
+        isAlgoliaActive={isAlgoliaActive}
+        heroImages={heroImages}
+        titleImages={titleImages}
+      />
     </NavbarLayout>
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,4 +19,4 @@ export { TOCCollapsible } from './components/TOCCollapsible';
 export { TOCItems } from './components/TOCItems';
 export { TOCItemTree } from './components/TOCItems/Tree';
 
-export { SearchPage } from './components/SearchPage'
+export { SearchPage } from './components/SearchPage';


### PR DESCRIPTION
Due to React IDE not having Algolia or ThemeSwitcher, we also needed to pass related props (`isThemeSwitcherShown` and `isAlgoliaActive`) to further components like `NavbarMobileSidebar`. It's a small patch that guarantees @swmansion-t-rex-ui working on IDE docs and at the same times doesn't brake other docs.