### PR TITLE
Move labels from hardcoded to passed as a prop

### DIFF
--- a/src/components/DocSidebar/Desktop/Content/index.tsx
+++ b/src/components/DocSidebar/Desktop/Content/index.tsx
@@ -15,6 +15,8 @@ export interface DocSidebarDesktopContentProps {
   className?: string;
   path: string;
   sidebar: PropSidebarItem[];
+  experimentalItems?: string[];
+  newItems?: string[];
 }
 function useShowAnnouncementBar() {
   const { isActive } = useAnnouncementBar();
@@ -33,6 +35,8 @@ export default function DocSidebarDesktopContent({
   path,
   sidebar,
   className,
+  experimentalItems,
+  newItems,
 }: DocSidebarDesktopContentProps) {
   const showAnnouncementBar = useShowAnnouncementBar();
   return (
@@ -49,7 +53,13 @@ export default function DocSidebarDesktopContent({
         className
       )}>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
-        <DocSidebarItems items={sidebar} activePath={path} level={1} />
+        <DocSidebarItems
+          newItems={newItems}
+          experimentalItems={experimentalItems}
+          items={sidebar}
+          activePath={path}
+          level={1}
+        />
       </ul>
     </nav>
   );

--- a/src/components/DocSidebar/Desktop/index.tsx
+++ b/src/components/DocSidebar/Desktop/index.tsx
@@ -14,6 +14,8 @@ function DocSidebarDesktop({
   heroImages,
   titleImages,
   isHidden,
+  experimentalItems,
+  newItems,
 }: DocSidebarProps) {
   const {
     navbar: { hideOnScroll },
@@ -36,7 +38,12 @@ function DocSidebarDesktop({
           className={styles.sidebarLogo}
         />
       )}
-      <Content path={path} sidebar={sidebar} />
+      <Content
+        newItems={newItems}
+        experimentalItems={experimentalItems}
+        path={path}
+        sidebar={sidebar}
+      />
       {hideable && <CollapseButton onClick={onCollapse} />}
     </div>
   );

--- a/src/components/DocSidebar/Mobile/index.tsx
+++ b/src/components/DocSidebar/Mobile/index.tsx
@@ -9,12 +9,19 @@ import { type DocSidebarProps } from '..';
 import { DocSidebarItems } from '../../DocSidebarItems';
 
 // eslint-disable-next-line react/function-component-definition
-const DocSidebarMobileSecondaryMenu = ({ sidebar, path }: DocSidebarProps) => {
+const DocSidebarMobileSecondaryMenu = ({
+  newItems,
+  experimentalItems,
+  sidebar,
+  path,
+}: DocSidebarProps) => {
   const mobileSidebar = useNavbarMobileSidebar();
   return (
     <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
       <DocSidebarItems
         items={sidebar}
+        newItems={newItems}
+        experimentalItems={experimentalItems}
         activePath={path}
         onItemClick={(item) => {
           // Mobile sidebar should only be closed if the category has a link

--- a/src/components/DocSidebar/index.tsx
+++ b/src/components/DocSidebar/index.tsx
@@ -10,6 +10,8 @@ export interface DocSidebarProps {
   isHidden: boolean;
   heroImages?: { logo: string; title: string };
   titleImages?: { light: string; dark: string };
+  experimentalItems?: string[];
+  newItems?: string[];
 }
 
 export function DocSidebar(props: DocSidebarProps) {

--- a/src/components/DocSidebarItem/Category/index.tsx
+++ b/src/components/DocSidebarItem/Category/index.tsx
@@ -193,6 +193,8 @@ export default function DocSidebarItemCategory({
       <Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>
         <DocSidebarItems
           items={items as unknown as PropSidebarItemLink[]}
+          newItems={props.newItems}
+          experimentalItems={props.experimentalItems}
           tabIndex={collapsed ? -1 : 0}
           onItemClick={onItemClick}
           activePath={activePath}

--- a/src/components/DocSidebarItem/index.tsx
+++ b/src/components/DocSidebarItem/index.tsx
@@ -10,12 +10,21 @@ export interface DocSidebarItemProps {
   tabIndex?: number;
   item: PropSidebarItem;
   index: number;
+  newItems?: string[];
+  experimentalItems?: string[];
 }
 
 export function DocSidebarItem({ item, ...props }: DocSidebarItemProps) {
   switch (item.type) {
     case 'category':
-      return <DocSidebarItemCategory item={item} {...props} />;
+      return (
+        <DocSidebarItemCategory
+          newItems={props.newItems}
+          experimentalItems={props.experimentalItems}
+          item={item}
+          {...props}
+        />
+      );
     case 'html':
       return <DocSidebarItemHtml item={item} {...props} />;
     case 'link':

--- a/src/components/DocSidebarItems/index.tsx
+++ b/src/components/DocSidebarItems/index.tsx
@@ -5,11 +5,10 @@ import SidebarLabel from '../SidebarLabel';
 import styles from './styles.module.css';
 import type { DocSidebarItemProps } from '../DocSidebarItem';
 
-const EXPERIMENTAL_APIs = ['shared-element-transitions/overview'];
-const NEW_APIS = ['animations/withClamp'];
-
 interface DocSidebarItemsProps
   extends Omit<DocSidebarItemProps, 'item' | 'index'> {
+  experimentalItems?: string[];
+  newItems?: string[];
   items: any;
 }
 
@@ -17,17 +16,25 @@ interface DocSidebarItemsProps
 // TODO this triggers whole sidebar re-renders on navigation
 const DocSidebarItems = memo(function DocSidebarItems({
   items,
+  experimentalItems,
+  newItems,
   ...props
 }: DocSidebarItemsProps) {
   return (
     <DocSidebarItemsExpandedStateProvider>
       {items.map((item: any, index: any) => (
         <div className={styles.wrapper} key={`${item.docId}-${index}`}>
-          <DocSidebarItem item={item} index={index} {...props} />
-          {EXPERIMENTAL_APIs.includes(item.docId!) && (
+          <DocSidebarItem
+            newItems={newItems}
+            experimentalItems={experimentalItems}
+            item={item}
+            index={index}
+            {...props}
+          />
+          {experimentalItems && experimentalItems.includes(item.docId!) && (
             <SidebarLabel key={item.docId} type="experimental" />
           )}
-          {NEW_APIS.includes(item.docId!) && (
+          {newItems && newItems.includes(item.docId!) && (
             <SidebarLabel key={item.docId} type="new" />
           )}
         </div>


### PR DESCRIPTION
For more customisation label, before hardcoded, are now passed as a prop to `<DocSidebar/>` in your proejct. `newItems` and  `experimentalItems` are string arrays, that should have desired item docsId for example if we want to have new next to `withClamp` and `useSharedValue` (from Reanimated docs) in our sidebar, our `newItems` array should look like this

```
const newItems = ['animations/withClamp', 'core/useSharedValue']



<img width="184" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/950f3a51-adcf-4e0e-b0d8-e193e8f37e5c">
<img width="218" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/a69027c9-a802-4b44-8cc9-5c41ef41d582">
