### PR TITLE
Make vite more readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "@docsearch/js": "^3.6.0",
     "@docsearch/react": "^3.6.0",
     "@docusaurus/core": "^2.4.3",
     "@docusaurus/module-type-aliases": "^2.4.3",

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -69,7 +69,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }: any) {
     }
     return Promise.all([
       import('@docsearch/react/modal' as any),
-      import('@docsearch/react/style' as any),
+      // import('@docsearch/react/style' as any),
       import('./styles.module.css'),
     ]).then(([{ DocSearchModal: Modal }]) => {
       DocSearchModal = Modal;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'vite'
-import { extname, relative, resolve } from 'path'
-import { fileURLToPath } from 'node:url'
-import { glob } from 'glob'
+import { defineConfig } from 'vite';
+import { extname, relative, resolve } from 'path';
+import { fileURLToPath } from 'node:url';
+import { glob } from 'glob';
 
-import dts from 'vite-plugin-dts'
-import react from '@vitejs/plugin-react'
-import { libInjectCss } from 'vite-plugin-lib-inject-css'
+import dts from 'vite-plugin-dts';
+import react from '@vitejs/plugin-react';
+import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -17,6 +17,27 @@ export default defineConfig({
     'src/assets/**/*.css',
   ],
   build: {
+    sourcemap: true,
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: false,
+        drop_debugger: false,
+        ecma: 2020,
+        keep_fnames: true,
+        keep_classnames: true,
+        module: true,
+        toplevel: false,
+      },
+      format: {
+        comments: false,
+        beautify: true,
+      },
+      mangle: {
+        keep_fnames: true,
+        keep_classnames: true,
+      },
+    },
     rollupOptions: {
       external: [
         'react',
@@ -58,4 +79,4 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-})
+});


### PR DESCRIPTION
Before it was almost impossible to debug our installed package from inside project - it was not easy to read. Now bundle grew in size (from ~200kB to ~800kB) but the minified code is human-readable and you can `console.log` from it.

There is no reloading the node module, so all console.logs must be written before first `yarn start`.