### PR TITLE
Fix for mobile Search Modal

### DIFF
--- a/src/components/SearchBar/styles.module.css
+++ b/src/components/SearchBar/styles.module.css
@@ -1,11 +1,13 @@
 [class*='DocSearch-Modal'] {
   --docsearch-modal-background: var(--swm-off-background);
   --docsearch-spacing: 16px;
+  margin: 100px auto auto !important;
 }
 
 @media (max-width: 768px) {
   [class*='DocSearch-Modal'] {
     --docsearch-spacing: 24px;
+    margin: var(--ifm-navbar-height) auto auto !important;
   }
 }
 
@@ -86,10 +88,11 @@
 [class*='DocSearch-Hits'] mark {
   text-decoration: underline;
   text-underline-offset: 2px;
-} 
+}
 
-[class*='DocSearch-Hit-source'], [class*='DocSearch-Hits'] mark {
-  color: var(--swm-docsearch-hit-source-color) !important
+[class*='DocSearch-Hit-source'],
+[class*='DocSearch-Hits'] mark {
+  color: var(--swm-docsearch-hit-source-color) !important;
 }
 
 [class*='DocSearch-Hit-Container'] {


### PR DESCRIPTION
Fix for search modal on media width < 768px. For aesthetic purposes added more margin for search modal in media width > 768px


Before:

<img width="446" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/2b3759dc-9602-4516-9fdb-bc1f604389c9">


After:

<img width="445" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/84e73703-2a96-44d4-ac60-3ca112e97a20">


Before:

<img width="648" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/b964fd1c-b34e-4388-8710-b8ed8b1ca66d">

After:

<img width="648" alt="image" src="https://github.com/software-mansion-labs/t-rex-ui/assets/59940332/da71ff7f-33a2-40f7-9990-e63f69af19e0">

