### PR TITLE
Add prop for enabling dual variant logo

### DIFF
--- a/src/components/Logo/LogoStyling.tsx
+++ b/src/components/Logo/LogoStyling.tsx
@@ -53,6 +53,7 @@ const LogoStyling = (props: LogoWrapperProps): JSX.Element => {
     heroImages,
     imageClassName,
     titleClassName,
+    useLandingLogoDualVariant,
     ...propsRest
   } = props;
   const logoLink = useBaseUrl(logo?.href || '/');
@@ -87,7 +88,7 @@ const LogoStyling = (props: LogoWrapperProps): JSX.Element => {
       className={styles.link}
       {...propsRest}
       {...(logo?.target && { target: logo.target })}>
-      {logo && !isLanding ? (
+      {logo && (!isLanding || useLandingLogoDualVariant) ? (
         <>
           <LogoThemedImage
             logo={logo}

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -16,6 +16,7 @@ export function LogoWrapper({
   titleImages,
   heroImages,
   className,
+  useLandingLogoDualVariant,
 }: LogoWrapperProps) {
   // TODO:
   // instead of passing heroImages to DocSidebarDesktop pass them directly to Logo from project
@@ -25,6 +26,7 @@ export function LogoWrapper({
       <LogoStyling
         titleImages={titleImages}
         heroImages={heroImages}
+        useLandingLogoDualVariant={useLandingLogoDualVariant}
         imageClassName={clsx(className, styles.navbar__logo)}
         titleClassName={clsx(titleClassName, styles.navbar__title)}
       />

--- a/src/components/Navbar/Content/index.tsx
+++ b/src/components/Navbar/Content/index.tsx
@@ -70,6 +70,7 @@ export default function NavbarContent({
   heroImages,
   titleImages,
   isAlgoliaActive,
+  useLandingLogoDualVariant,
   isThemeSwitcherShown,
 }: NavbarProps) {
   const windowSize = useWindowSize();
@@ -87,7 +88,11 @@ export default function NavbarContent({
       left={
         <>
           <div className={styles.logoWrapper}>
-            <NavbarLogo heroImages={heroImages} titleImages={titleImages} />
+            <NavbarLogo
+              useLandingLogoDualVariant={useLandingLogoDualVariant}
+              heroImages={heroImages}
+              titleImages={titleImages}
+            />
           </div>
           {!isLanding && <NavbarItems items={leftItems} />}
           {!searchBarItem && !isMobile && !isLanding && searchComponent}

--- a/src/components/Navbar/Logo/index.tsx
+++ b/src/components/Navbar/Logo/index.tsx
@@ -4,11 +4,13 @@ import { LogoWrapper as Logo } from '../../Logo';
 export default function NavbarLogo({
   heroImages,
   titleImages,
+  useLandingLogoDualVariant,
 }: NavbarProps) {
   return (
     <Logo
       heroImages={heroImages}
       titleImages={titleImages}
+      useLandingLogoDualVariant={useLandingLogoDualVariant}
       imageClassName="navbar__logo"
       titleClassName="navbar__title text--truncate"
     />

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,6 +4,7 @@ import NavbarContent from './Content';
 export interface NavbarProps {
   heroImages?: { logo: string; title?: string };
   titleImages?: { light: string; dark: string };
+  useLandingLogoDualVariant?: boolean;
   isAlgoliaActive?: boolean;
   isThemeSwitcherShown?: boolean;
 }
@@ -13,6 +14,7 @@ export function Navbar({
   titleImages,
   isAlgoliaActive = true,
   isThemeSwitcherShown = true,
+  useLandingLogoDualVariant = false,
 }: NavbarProps) {
   return (
     <NavbarLayout
@@ -21,6 +23,7 @@ export function Navbar({
       <NavbarContent
         isThemeSwitcherShown={isThemeSwitcherShown}
         isAlgoliaActive={isAlgoliaActive}
+        useLandingLogoDualVariant={useLandingLogoDualVariant}
         heroImages={heroImages}
         titleImages={titleImages}
       />


### PR DESCRIPTION
Before, in our documentation, logo was available to set in two variants only on documentation page. It was set through docusaurus.config.js in navbar > logo section.

Now, when new documentation arise - React Native Screens Landing - we need to have a possiblity to set it also on landing site. To solve that we added `useLandingLogoDualVariant` prop that defines whether this documentation uses both light and dark mode logos on landing. The source for dark and light logos are set in docusaurus.config.js, just as before.