### PR TITLE
Fix missing styles on SearchBar

### DIFF
--- a/packages/t-rex-ui/src/components/AlgoliaSearchBar/index.tsx
+++ b/packages/t-rex-ui/src/components/AlgoliaSearchBar/index.tsx
@@ -2,6 +2,7 @@ import styles from './styles.module.css';
 
 import NavbarSearch from '../Navbar/Search';
 import SearchBar from '../SearchBar/SearchBar';
+import '@docsearch/css';
 
 const AlgoliaSearchBar = () => {
   return (


### PR DESCRIPTION
before:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/fb4a3597-2480-4770-be8b-792147f92915">
![image](https://github.com/user-attachments/assets/561c9dea-4058-4754-89da-dbe8b3fa366f)

after:
<img width="967" alt="image" src="https://github.com/user-attachments/assets/91cc9d6f-1869-4f10-abd3-ddfd5bcc997a">

(the command key in the searchBar is pressed because i needed to use it to make screenshot 👍 )

## Test plan
1. Run `yarn` in root
2. Run `yarn watch` in `/packages/t-rex-ui`
3. Run `yarn start` in `/packages/docs` -> if you can't see the styling on SearchBar run `yarn cache clean` and/or `yarn build`