### PR TITLE
fix: `next` version never set as active

### DIFF
--- a/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/index.tsx
@@ -10,7 +10,15 @@ import { useThemeConfig } from '@docusaurus/theme-common';
 import NavbarNavLink from '../../../NavbarItem/NavbarNavLink';
 
 function isActive(path: string, locationPathname: string) {
-  return locationPathname.startsWith(path);
+  if (locationPathname === path) {
+    return true;
+  }
+
+  if (locationPathname.startsWith(path)) {
+    return true;
+  }
+
+  return false;
 }
 
 function useNavbarItems() {


### PR DESCRIPTION
Due to shady `isActive` check the `next` version of docs were never set, as was overwritten by default version.

For example `4.x` docs location is `docs/next`, the `path` for `3.x` is `docs` as it is default, and path for `4.x` is `docs/next`, so when function found `3.x` using `startsWith` it thought it's active version. In every case other than current default (`docs`) the `path` will equal the `location`, so current `isActive` first checks for equality and then checks (as it has done before) if `location.startsWith(path)`. The change is not breaking, it's only a double guard.