### PR TITLE
feat: Add customization of ad banner in TOC

### DIFF
--- a/packages/t-rex-ui/src/components/TOCItems/index.tsx
+++ b/packages/t-rex-ui/src/components/TOCItems/index.tsx
@@ -4,8 +4,7 @@ import {
   useTOCHighlight,
   useFilteredAndTreeifiedTOC,
 } from '@docusaurus/theme-common/internal';
-import { TOCItemTree } from './Tree';
-import { type TOCProp } from './Tree';
+import { TOCItemTree, type TOCProp } from './Tree';
 import type { TOCItem } from '@docusaurus/mdx-loader';
 
 import {
@@ -17,6 +16,7 @@ import styles from './styles.module.css';
 
 interface TOCItemsProps {
   toc: TOCItem[];
+  slot?: React.ReactNode;
   minHeadingLevel?: number;
   maxHeadingLevel?: number;
   className?: string;
@@ -26,6 +26,7 @@ interface TOCItemsProps {
 
 export function TOCItems({
   toc,
+  slot,
   className = 'table-of-contents table-of-contents__left-border',
   linkClassName = 'table-of-contents__link',
   linkActiveClassName = undefined,
@@ -63,18 +64,20 @@ export function TOCItems({
         linkClassName={linkClassName}
         {...props}
       />
-      <div className={styles.hireUsContainer}>
-        <p>We are Software Mansion.</p>
-        <div className={styles.buttonContainer}>
-          <HomepageButton
-            href="https://swmansion.com/contact/projects?utm_source=rnos-docs&utm_medium=sidebar"
-            title="Hire us"
-            backgroundStyling={ButtonStyling.TOC}
-            borderStyling={BorderStyling.TOC}
-            enlarged={false}
-          />
+      {slot ?? (
+        <div className={styles.hireUsContainer}>
+          <p>We are Software Mansion.</p>
+          <div className={styles.buttonContainer}>
+            <HomepageButton
+              href="https://swmansion.com/contact/projects?utm_source=rnos-docs&utm_medium=sidebar"
+              title="Hire us"
+              backgroundStyling={ButtonStyling.TOC}
+              borderStyling={BorderStyling.TOC}
+              enlarged={false}
+            />
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
This PR introduces customization of ad banner in TOC:
It can be customize by setting `slot` prop in `TOCItems` wrapper like that:

In your documentation's `/src/theme/TOCItems/index.js`

```tsx

import React from 'react';
import { TOCItems } from '@swmansion/t-rex-ui';

export default function TOCItemsWrapper(props) {
  const Slot = () => {
    return (
      <div style={{ width: '100', height: '100', backgroundColor: 'red' }}>
        <h3>Petarda</h3>
      </div>
    );
  };

  return (
    <>
      <TOCItems slot={<Slot />} {...props} />
    </>
  );
}


```
Result:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/f413d7b7-9b67-416c-8969-f560db986cf3" />

If no slot is provided, or you just do default import from `t-rex-ui`:

```tsx

import { TOCItems } from '@swmansion/t-rex-ui';

export default TOCItems;


```

It still yields the same result as before

<img width="645" alt="image" src="https://github.com/user-attachments/assets/3c3ace89-2352-4f70-a4e2-35dafa5ee3b0" />
