### PR TITLE
fix: versions on mobile sidebar not visible

### DIFF
--- a/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/index.tsx
@@ -73,6 +73,7 @@ export default function NavbarMobileSidebarLayout({
         </div>
         <div className={styles.sidebarVersions}>
           <span className={styles.sidebarVersionLabel}>Versions:</span>
+          <div className={styles.sidebarVersionLinks}>
           {reversed.map((version) => {
             return (
               <a
@@ -90,6 +91,8 @@ export default function NavbarMobileSidebarLayout({
               </a>
             );
           })}
+
+          </div>
         </div>
       </div>
     </div>

--- a/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/styles.module.css
+++ b/packages/t-rex-ui/src/components/Navbar/MobileSidebar/Layout/styles.module.css
@@ -45,11 +45,20 @@
 
 .sidebarVersionLabel {
   margin-right: 12px;
+  
+}
+.sidebarVersions {
+  display: flex;
 }
 
 .sidebarVersion {
   margin: 0 8px;
   color: var(--swm-sidebar-elements-version-inactive);
+}
+
+.sidebarVersionLinks {
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .active {


### PR DESCRIPTION
This PR resolves issue #35 where sidebar on mobile was not showing all the versions as they were cut off.

https://github.com/user-attachments/assets/364ffe99-3357-44ea-b52d-82241c315592


