### PR TITLE
Improvements in clarity and readability for Version Banners

### DIFF
--- a/packages/t-rex-ui/src/components/DocVersionBanner/index.tsx
+++ b/packages/t-rex-ui/src/components/DocVersionBanner/index.tsx
@@ -28,7 +28,7 @@ function UnreleasedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+        'This is the unreleased documentation for {siteTitle}, version {versionLabel}.'
       }
     </Translate>
   );
@@ -49,7 +49,7 @@ function UnmaintainedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+        'This is the documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
       }
     </Translate>
   );
@@ -96,7 +96,7 @@ function LatestVersionSuggestionLabel({
         ),
       }}>
       {
-        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+        'For up-to-date documentation, refer to the {latestVersionLink} ({versionLabel}).'
       }
     </Translate>
   );


### PR DESCRIPTION
Add the definite articles and rephrase two sentences. Since the corrections for definite articles appear straightforward, I'm interested to hear your thoughts on the other two changes.

The first one:
`[...] documentation for {siteTitle} {versionLabel} version.` -> `[...] documentation for {siteTitle}, version {versionLabel}.`

I believe that the second version is preferable because it clearly distinguishes between the package and its version. Consider the following example:
<img width="560" height="48" alt="image" src="https://github.com/user-attachments/assets/7d42e4e1-cb3c-44c2-bad0-287792be5894" />
The word `Next` might blend with the package name. The second version provides a clear separation.

The second: 
`see the {latestVersionLink} ({versionLabel}).` -> `refer to the {latestVersionLink} ({versionLabel}).`
Just my personal preference ;p