### PR TITLE
fix(t-rex-ui): load sidepanel on client

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -116,7 +116,7 @@ const config = {
                 href: 'https://docs.swmansion.com/react-native-executorch/',
                 label: 'ExecuTorch',
                 target: '_blank',
-              }
+              },
             ],
           },
           {

--- a/packages/t-rex-ui/src/components/SearchBar/styles.module.css
+++ b/packages/t-rex-ui/src/components/SearchBar/styles.module.css
@@ -189,3 +189,22 @@
     box-sizing: border-box !important;
   }
 }
+
+[class*='DocSearch-Sidepanel-Container'][class*='is-open'] {
+  transform: translateX(0) !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+@keyframes ds-fade-in-button {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+[class*='DocSearch-SidepanelButton'] {
+  animation: ds-fade-in-button 0.4s ease-out forwards !important;
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where it was impossible to build docs with sidepanel chat enabled (it worked with `yarn start`, but did not work with `yarn build -> yarn serve`) as `DocSearchSidepanel` can't be rendered without browser.

This PR:
- wraps `DocSearchSidepanel` in `<BrowserOnly>` block and moves it to modal to keep its all functionalities
- adds opacity animation, so the `DocSearch-SidepanelButton` does not "snap" on first render (because it's client component it renders with a slight delay)

## Screenshots/Videos

https://github.com/user-attachments/assets/26d7ff1f-dc81-4e0d-bfd4-0474d7e6e113

https://github.com/user-attachments/assets/c4480c28-233b-419a-aa71-00cada7d82c5

