### PR TITLE
feat: resolve version-switch links to page counterparts via opt-in map

### DIFF
--- a/packages/t-rex-ui/src/components/DocVersionBanner/index.tsx
+++ b/packages/t-rex-ui/src/components/DocVersionBanner/index.tsx
@@ -4,6 +4,7 @@ import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import {
   useActivePlugin,
+  useActiveDocContext,
   useDocVersionSuggestions,
   useDocsPreferredVersion,
   useDocsVersion,
@@ -11,6 +12,10 @@ import {
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import type { PropVersionMetadata } from '@docusaurus/plugin-content-docs';
 import styles from '../Admonition/styles.module.css';
+import {
+  findVersionCounterpartDoc,
+  useVersionCounterpartMap,
+} from '../../utils/versionCounterpart';
 
 function UnreleasedVersionLabel({
   siteTitle,
@@ -115,12 +120,21 @@ function DocVersionBannerEnabled({
   const getVersionMainDoc = (version: any) =>
     version.docs.find((doc: any) => doc.id === version.mainDocId);
   const { savePreferredVersionName } = useDocsPreferredVersion(pluginId);
+  const { activeDoc } = useActiveDocContext(pluginId);
+  const counterpartMap = useVersionCounterpartMap();
   const { latestDocSuggestion, latestVersionSuggestion } =
     useDocVersionSuggestions(pluginId);
-  // Try to link to same doc in latest version (not always possible), falling
-  // back to main doc of latest version
+  // Try to link to same doc in latest version (not always possible). When the
+  // doc id changed between versions, consult the opt-in counterpart map before
+  // falling back to the main doc of the latest version.
   const latestVersionSuggestedDoc =
-    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+    latestDocSuggestion ??
+    findVersionCounterpartDoc(
+      activeDoc,
+      latestVersionSuggestion,
+      counterpartMap,
+    ) ??
+    getVersionMainDoc(latestVersionSuggestion);
   return (
     <div
       className={clsx(

--- a/packages/t-rex-ui/src/components/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/t-rex-ui/src/components/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -11,6 +11,10 @@ import { useLocation } from '@docusaurus/router';
 import DefaultNavbarItem from './DefaultNavbarItem';
 import DropdownNavbarItem from './DropdownNavbarItem';
 import { NavbarNavLinkProps } from './NavbarNavLink';
+import {
+  findVersionCounterpartDoc,
+  useVersionCounterpartMap,
+} from '../../utils/versionCounterpart';
 
 const getVersionMainDoc = (version: GlobalVersion) =>
   version.docs.find((doc) => doc.id === version.mainDocId);
@@ -34,12 +38,19 @@ export default function DocsVersionDropdownNavbarItem({
   const { search, hash } = useLocation();
   const activeDocContext = useActiveDocContext(docsPluginId);
   const versions = useVersions(docsPluginId);
+  const counterpartMap = useVersionCounterpartMap();
   const { savePreferredVersionName } = useDocsPreferredVersion(docsPluginId);
   const versionLinks = versions.map((version) => {
-    // We try to link to the same doc, in another version
-    // When not possible, fallback to the "main doc" of the version
+    // We try to link to the same doc, in another version. When the doc id
+    // changed between versions, we consult the opt-in counterpart map. When
+    // neither is possible, fallback to the "main doc" of the version.
     const versionDoc =
       activeDocContext.alternateDocVersions[version.name] ??
+      findVersionCounterpartDoc(
+        activeDocContext.activeDoc,
+        version,
+        counterpartMap,
+      ) ??
       getVersionMainDoc(version);
     return {
       label: version.label,

--- a/packages/t-rex-ui/src/main.ts
+++ b/packages/t-rex-ui/src/main.ts
@@ -17,6 +17,8 @@ export { DocItemMetadata } from './components/DocItem/Metadata';
 export { DocItemLayout } from './components/DocItem/Layout';
 export { DocVersionBanner } from './components/DocVersionBanner';
 
+export type { VersionCounterpartMap } from './utils/versionCounterpart';
+
 export { TOCCollapsible } from './components/TOCCollapsible';
 export { TOCItems } from './components/TOCItems';
 export { TOCItemTree } from './components/TOCItems/Tree';

--- a/packages/t-rex-ui/src/utils/versionCounterpart.ts
+++ b/packages/t-rex-ui/src/utils/versionCounterpart.ts
@@ -1,0 +1,46 @@
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {
+  GlobalDoc,
+  GlobalVersion,
+} from '@docusaurus/plugin-content-docs/client';
+
+/**
+ * Opt-in map used to link a page to its counterpart in the latest docs version
+ * when the doc id changed between versions (e.g. after a docs reorganization).
+ *
+ * Keys and values are doc ids (`GlobalDoc.id`), for example:
+ * `{ 'api/hooks/useAnimatedStyle': 'core/useAnimatedStyle' }`.
+ *
+ * Provide it through `customFields.versionCounterpartMap` in the site config.
+ * When absent, the version dropdown and the version banner keep their default
+ * behavior (fall back to the latest version's main doc).
+ */
+export type VersionCounterpartMap = Record<string, string>;
+
+export function useVersionCounterpartMap(): VersionCounterpartMap | undefined {
+  const { siteConfig } = useDocusaurusContext();
+  return siteConfig.customFields?.versionCounterpartMap as
+    | VersionCounterpartMap
+    | undefined;
+}
+
+/**
+ * Resolves the current page's counterpart in the target version using the
+ * opt-in map. Returns `undefined` (so callers can fall through to their
+ * default) when there is no map, no active doc, the target is not the latest
+ * version, or the map has no entry for the current page.
+ */
+export function findVersionCounterpartDoc(
+  activeDoc: GlobalDoc | undefined,
+  targetVersion: GlobalVersion,
+  counterpartMap: VersionCounterpartMap | undefined,
+): GlobalDoc | undefined {
+  if (!counterpartMap || !activeDoc || !targetVersion.isLast) {
+    return undefined;
+  }
+  const targetId = counterpartMap[activeDoc.id];
+  if (!targetId) {
+    return undefined;
+  }
+  return targetVersion.docs.find((doc) => doc.id === targetId);
+}


### PR DESCRIPTION
## Summary

When a docs page's id changes between versions (e.g. after a docs reorganization), the version **dropdown** and the "latest version" **banner** can't match the page across versions, so they fall back to the latest version's home page. This adds an **opt-in** `customFields.versionCounterpartMap` (a `{ oldDocId: newDocId }` map read via `useVersionCounterpartMap()`) so both surfaces link to the actual counterpart page instead.

Each surface gets one lookup spliced into its existing fallback chain:

```
sameDocIdInTargetVersion  ??  counterpartFromMap  ??  mainDocOfVersion
```

`findVersionCounterpartDoc()` only resolves when a map is provided, the current page has an entry, and the target is the latest version (`isLast`). It returns a real doc from the target version, so generated links are always valid.

Sites that don't set `customFields.versionCounterpartMap` are completely unaffected: the resolver returns `undefined` on its first guard and the `??` chains behave exactly as before. No `themeConfig`/schema changes.

Part 1 of 2 - this is the library change. Part 2 adopts it in the Reanimated docs site (adds its map via `customFields`) once this is released.

## Test plan

Verified by building the Reanimated docs against this branch:

- old → latest switches land on the correct counterpart on both the dropdown and the banner
- pages with no counterpart still fall back to home
- the build passes with `onBrokenLinks: 'throw'`
