### PR TITLE
fix: TopbarBanner not refilling ad zone after client-side navigation & release 1.3.5

### DIFF
--- a/packages/t-rex-ui/package.json
+++ b/packages/t-rex-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/t-rex-ui",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/packages/t-rex-ui/src/components/TopbarBanner/TopbarBannerClient.tsx
+++ b/packages/t-rex-ui/src/components/TopbarBanner/TopbarBannerClient.tsx
@@ -29,6 +29,22 @@ const SCRIPT_SRC = 'https://swm-delivery.com/www/assets/js/lib.js';
 
 const FALLBACK_BG_COLOR = '#2a47ff';
 
+// SCRIPT_SRC's controller (window.contentAsync[contentId]) only auto-fills
+// <ins> zones once, on page load. Later remount needs a manual refresh.
+type ContentAsyncController = { refresh?: () => void };
+
+const triggerContentAsyncRefresh = (contentId: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const registry = (
+    window as unknown as {
+      contentAsync?: Record<string, ContentAsyncController>;
+    }
+  ).contentAsync;
+  registry?.[contentId]?.refresh?.();
+};
+
 const useIsoLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -365,6 +381,8 @@ export const TopbarBanner = ({
         ? [{ zoneId, contentId, fallbackBgColor }]
         : [];
 
+  const contentIdsKey = normalizedZones.map((zone) => zone.contentId).join(',');
+
   const [zoneStates, setZoneStates] = useState<ZoneState[]>(() =>
     normalizedZones.map(() => ({ height: 0, hasBanner: false }))
   );
@@ -415,6 +433,10 @@ export const TopbarBanner = ({
       return;
     }
     if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) {
+      const uniqueContentIds = Array.from(
+        new Set(contentIdsKey.split(',').filter(Boolean))
+      );
+      uniqueContentIds.forEach(triggerContentAsyncRefresh);
       return;
     }
 
@@ -422,7 +444,7 @@ export const TopbarBanner = ({
     script.async = true;
     script.src = SCRIPT_SRC;
     document.body.appendChild(script);
-  }, []);
+  }, [contentIdsKey]);
 
   // Arm transition only after the first frame is painted (double rAF), so the
   // reserved bar appears instantly but later size changes still animate.


### PR DESCRIPTION
Revive's loader script (window.contentAsync[contentId]) only auto-fills
`<ins>` zones once, on initial page load. On a client-side route change
(e.g. Docusaurus swapping pages), TopbarBanner remounts with a fresh,
empty `<ins>` that the loader never notices, so the bar collapses.

To fix that when the loader script is already present at mount, manually call the loader's
per-contentId refresh() to re-scan and fill the new zone.