### PR TITLE
feat: Add platforms circles

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ export default function TOCItemsWrapper(props) {
 }                                                                                        
 ```                                                              
 
+### Platform circles in the table of contents
+
+T-Rex UI can render small colored circles next to table of contents entries to indicate which platforms a given section (e.g. an API property) applies to. Add `[A]` (Android), `[I]` (iOS) and/or `[W]` (Web) markers at the end of a heading:
+
+```md
+### rippleColor [A]
+```
+
+The markers are stripped from the rendered heading — only the ToC entry gets the circles. To display platform badges next to the heading itself, wrap it in the `Badges` component.
+
+Markers must be placed at the end of the heading, after any inline formatting. Only `.mdx` documents are supported (the circles are injected as MDX JSX nodes), and they are shown in the desktop ToC only, not in the mobile "On this page" dropdown.
+
+Enable it by wiring the two remark plugins into the docs options in `docusaurus.config.js`:
+
+```js
+const platformCircles = require('@swmansion/t-rex-ui/platform-circles');
+
+// in the classic preset options:
+docs: {
+  beforeDefaultRemarkPlugins: [platformCircles.processHeaderMarkers],
+  remarkPlugins: [platformCircles.removeHeaderJSX],
+},
+```
+
+The circles are rendered in the gutter to the left of the ToC entry, so entries without circles keep the same text alignment.
+
+If the site defines the platform badge colors (`--swm-platform-badge-{android,ios,web}-background`), the circles use them automatically, so they stay consistent with the `Badges` component. The exception is the iOS circle in the dark theme, which defaults to `#ffffff` regardless of the badge color — a dark badge pill stays readable on a dark background, a dark circle does not. The colors can also be overridden independently of the badges with dedicated CSS variables:
+
+```css
+:root {
+  --swm-platform-indicator-android-background: #34a853;
+  --swm-platform-indicator-ios-background: #000000;
+  --swm-platform-indicator-web-background: #1067c4;
+}
+```
+
+The values above are also the built-in fallbacks used when neither the badge nor the indicator variables are defined.
+
 ### TopbarBanner
 
 The T-Rex UI `TopbarBanner` renders a Adserver top bar above the navbar. It reserves its height **before hydration** (no content shift on reload) and serves content **server-side** — banners are swapped/rotated on the adserver with no redeploy. The component is shared; each site declares only its own zones (a small config object).

--- a/packages/docs/docs/fundamentals/lorem.mdx
+++ b/packages/docs/docs/fundamentals/lorem.mdx
@@ -21,7 +21,7 @@ Pellentesque lacinia ultrices ex, sed pulvinar velit lobortis vitae. Curabitur d
 
 
 <Badges platforms={['android', 'ios']} version="4.1.1">
-### Lorem Ipsum 
+### Lorem Ipsum [A][I]
 </Badges>
 
 Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse molestie tellus ac nulla finibus vulputate in at lorem. Mauris consequat iaculis sem, id egestas odio tincidunt ultricies.
@@ -30,7 +30,8 @@ Etiam magna leo, condimentum sed bibendum et, fringilla id lectus. Aliquam sed d
 
 ## Suspendisse eu tortor lorem. Sed dictum neque non libero vulputate efficitur.
 
-### Integer malesuada efficitur commodo. Duis fermentum consectetur libero, a venenatis ante molestie sit amet.
+### Integer malesuada efficitur commodo. Duis fermentum consectetur libero, a venenatis ante molestie sit amet. [W]
+
 
 Quisque vulputate nibh sed justo maximus pretium. Sed a sodales ante, euismod suscipit felis. Maecenas molestie in elit in condimentum. Fusce id nibh non mi sollicitudin imperdiet at a quam.
 

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -6,6 +6,7 @@
 
 const lightCodeTheme = require('./src/theme/CodeBlock/highlighting-light.js');
 const darkCodeTheme = require('./src/theme/CodeBlock/highlighting-dark.js');
+const platformCircles = require('@swmansion/t-rex-ui/platform-circles');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -49,6 +50,8 @@ const config = {
               label: '3.x',
             },
           },
+          beforeDefaultRemarkPlugins: [platformCircles.processHeaderMarkers],
+          remarkPlugins: [platformCircles.removeHeaderJSX],
         },
         blog: {
           showReadingTime: false,

--- a/packages/t-rex-ui/package.json
+++ b/packages/t-rex-ui/package.json
@@ -8,7 +8,8 @@
     ".": "./dist/main.js",
     "./topbar-banner": "./dist/components/TopbarBanner/shared.js",
     "./theme": "./theme.cjs",
-    "./preset": "./preset.cjs"
+    "./preset": "./preset.cjs",
+    "./platform-circles": "./plugin/platform-circles.js"
   },
   "files": [
     "dist",
@@ -43,7 +44,8 @@
     "remark-mdx": "^3.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@docsearch/core": "^4.4.0",

--- a/packages/t-rex-ui/plugin/platform-circles.js
+++ b/packages/t-rex-ui/plugin/platform-circles.js
@@ -1,0 +1,72 @@
+import { visit } from 'unist-util-visit';
+
+const platformClasses = {
+  '[A]': 'platform-indicator-android',
+  '[I]': 'platform-indicator-ios',
+  '[W]': 'platform-indicator-web',
+};
+
+const MARKER_REGEX = /\s*(\[A\]|\[I\]|\[W\])/g;
+
+const processHeaderMarkers = () => {
+  return (ast) => {
+    visit(ast, 'heading', (node) => {
+      const lastChild = node.children[node.children.length - 1];
+
+      if (lastChild?.type !== 'text') {
+        return;
+      }
+
+      const markers = [...lastChild.value.matchAll(MARKER_REGEX)]
+        .map((match) => match[1])
+        .sort();
+
+      if (markers.length === 0) {
+        return;
+      }
+
+      lastChild.value = lastChild.value.replace(MARKER_REGEX, '').trimEnd();
+
+      if (lastChild.value === '') {
+        node.children.pop();
+      }
+
+      markers.forEach((marker) => {
+        node.children.push({
+          type: 'mdxJsxTextElement',
+          name: 'span',
+          attributes: [
+            {
+              type: 'mdxJsxAttribute',
+              name: 'className',
+              value: platformClasses[marker],
+            },
+          ],
+          children: [],
+        });
+      });
+    });
+  };
+};
+
+const removeHeaderJSX = () => {
+  return (ast) => {
+    const classes = Object.values(platformClasses);
+
+    visit(ast, 'heading', (node) => {
+      node.children = node.children.filter((child) => {
+        if (child.type === 'mdxJsxTextElement') {
+          const classAttr = child.attributes?.find(
+            (a) => a.name === 'className'
+          );
+
+          return !(classAttr && classes.includes(classAttr.value));
+        }
+
+        return true;
+      });
+    });
+  };
+};
+
+export { processHeaderMarkers, removeHeaderJSX };

--- a/packages/t-rex-ui/plugin/platform-circles.js
+++ b/packages/t-rex-ui/plugin/platform-circles.js
@@ -6,7 +6,11 @@ const platformClasses = {
   '[W]': 'platform-indicator-web',
 };
 
-const MARKER_REGEX = /\s*(\[A\]|\[I\]|\[W\])/g;
+const MARKER_REGEX = /\[[AIW]\]/g;
+
+// A run of markers at the end of the heading, optionally followed by an
+// explicit Docusaurus anchor ({#custom-id}), which always sits last
+const TRAILING_MARKERS_REGEX = /(?:\s*\[[AIW]\])+(?=\s*(?:\{#[^}]+\})?\s*$)/;
 
 const processHeaderMarkers = () => {
   return (ast) => {
@@ -17,15 +21,20 @@ const processHeaderMarkers = () => {
         return;
       }
 
-      const markers = [...lastChild.value.matchAll(MARKER_REGEX)]
-        .map((match) => match[1])
-        .sort();
+      const trailingMarkers = lastChild.value.match(TRAILING_MARKERS_REGEX);
 
-      if (markers.length === 0) {
+      if (!trailingMarkers) {
         return;
       }
 
-      lastChild.value = lastChild.value.replace(MARKER_REGEX, '').trimEnd();
+      const markers = [
+        ...new Set(trailingMarkers[0].match(MARKER_REGEX)),
+      ].sort();
+
+      lastChild.value = (
+        lastChild.value.slice(0, trailingMarkers.index) +
+        lastChild.value.slice(trailingMarkers.index + trailingMarkers[0].length)
+      ).trimEnd();
 
       if (lastChild.value === '') {
         node.children.pop();

--- a/packages/t-rex-ui/src/components/TOCItems/styles.module.css
+++ b/packages/t-rex-ui/src/components/TOCItems/styles.module.css
@@ -44,3 +44,57 @@
   background-color: transparent;
   color: var(--swm-navy-light-40);
 }
+
+@media (min-width: 997px) {
+  :global(.table-of-contents li) {
+    position: relative;
+  }
+
+  :global(.table-of-contents .platform-indicator-android),
+  :global(.table-of-contents .platform-indicator-ios),
+  :global(.table-of-contents .platform-indicator-web) {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+
+    /* Hang the circle in the gutter left of the entry, aligned with its first
+     line, so entries without circles keep the same text alignment */
+    position: absolute;
+    left: -14px;
+    top: 7px;
+  }
+
+  /* Stack additional circles further to the left */
+  :global(
+    .table-of-contents
+      [class*='platform-indicator-']
+      ~ [class*='platform-indicator-']
+  ) {
+    left: -24px;
+  }
+
+  :global(.table-of-contents .platform-indicator-android) {
+    background: var(
+      --swm-platform-indicator-android-background,
+      var(--swm-platform-badge-android-background, #34a853)
+    );
+  }
+
+  :global(.table-of-contents .platform-indicator-ios) {
+    background: var(
+      --swm-platform-indicator-ios-background,
+      var(--swm-platform-badge-ios-background, #000000)
+    );
+  }
+
+  :global([data-theme='dark'] .table-of-contents .platform-indicator-ios) {
+    background: var(--swm-platform-indicator-ios-background, #ffffff);
+  }
+
+  :global(.table-of-contents .platform-indicator-web) {
+    background: var(
+      --swm-platform-indicator-web-background,
+      var(--swm-platform-badge-web-background, #1067c4)
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4538,6 +4538,7 @@ __metadata:
     tsc-watch: "npm:^6.2.0"
     typescript: "npm:5.8.3"
     unified: "npm:^11.0.5"
+    unist-util-visit: "npm:^5.1.0"
     vite: "npm:^5.2.0"
     vite-plugin-dts: "npm:^3.8.3"
     vite-plugin-lib-inject-css: "npm:^2.0.1"
@@ -15964,6 +15965,17 @@ __metadata:
     unist-util-is: "npm:^6.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
   checksum: 10/f2bbde23641e9ade7640358c06ddeec0f38342322eb8e7819d9ee380b0f859d25d084dde22bf63db0280b3b2f36575f15aa1d6c23acf276c91c2493cf799e3b0
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "unist-util-visit@npm:5.1.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10/340fc1929062d21156200284105caad79cc188bd98f285b60aba887492a70e6e6cadbc7e383a68909c7e0fdd83f855cb9f4184ad8e5aa153eb2d810445aea8e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds platform circles to the table of contents - small colored dots next to ToC entries showing which platforms a section applies to (like in [React Native docs](https://reactnative.dev/docs/scrollview)). Ported from software-mansion/react-native-gesture-handler#3985.

Authors add `[A]` / `[I]` / `[W]` markers at the end of a heading:

```md
### rippleColor [A]
```

A new `@swmansion/t-rex-ui/platform-circles` export provides two remark plugins: one turns the markers into indicator spans before Docusaurus extracts the ToC, the other strips them from the rendered heading. Circles inherit the site's `--swm platform-badge-*-background` colors (overridable via `--swm-platform-indicator-*-background`); the `iOS` dot turns white in dark theme. Desktop ToC and `.mdx` only. Setup and usage documented in the `README`, demo in the example app.

## Test plan

Library + example-docs builds pass; verified visually in both themes on docs/fundamentals/lorem.